### PR TITLE
Naive neighbor search, create render manager class

### DIFF
--- a/src/sample/crowd/renderUtils.ts
+++ b/src/sample/crowd/renderUtils.ts
@@ -1,42 +1,227 @@
+
+import {
+  platformVertexArray,
+  platformVertexSize,
+  platformUVOffset,
+  platformPositionOffset,
+  platformVertexCount,
+} from '../../meshes/platform';
+
+import {
+  getGridLines,
+  gridLinesVertexSize,
+  gridLinesVertexCount,
+  gridLinesPositionOffset,
+  gridLinesUVOffset
+} from '../../meshes/gridLines';
+
+import {
+  cubeVertexArray,
+  cubeVertexSize,
+  cubeUVOffset,
+  cubePositionOffset,
+  cubeVertexCount,
+} from '../../meshes/cube';
+
+import renderWGSL from './shaders.wgsl';
+import crowdWGSL from './crowd.wgsl';
+import { mat4 } from 'gl-matrix';
+
+export class renderBufferManager {
+
+  device : GPUDevice;
+
+  platformVertexBuffer    : GPUBuffer;
+  gridLinesVertexBuffer   : GPUBuffer;
+  prototypeVertexBuffer   : GPUBuffer;
+
+  platformPipeline        : GPURenderPipeline;
+  gridLinesPipeline       : GPURenderPipeline;
+  crowdPipeline           : GPURenderPipeline;
+
+  platformUniformBuffer   : GPUBuffer;
+  gridLinesUniformBuffer  : GPUBuffer;
+  crowdUniformBuffer      : GPUBuffer;
+
+  platformBindGroup       : GPUBindGroup;
+  gridLinesBindGroup      : GPUBindGroup;
+  crowdBindGroup          : GPUBindGroup;
+
+  renderPassDescriptor    : GPURenderPassDescriptor;
+
+  constructor (device: GPUDevice, gridWidth: number, presentationFormat, presentationSize,
+               agentInstanceByteSize: number, agentPositionOffset: number, agentColorOffset: number) 
+  {
+    this.device = device;
+    this.initBuffers(gridWidth);
+    this.buildPipelines(presentationFormat, agentInstanceByteSize, agentPositionOffset, agentColorOffset);
+    this.setBindGroups();
+    this.setRenderPassDescriptor(presentationSize);
+  }
+
+  initBuffers(gridWidth: number) {
+    // Create vertex buffers for the platform and the grid lines
+    this.platformVertexBuffer = getVerticesBuffer(this.device, platformVertexArray);
+
+    // Compute the grid lines based on an input gridWidth
+    let gridLinesVertexArray = getGridLines(gridWidth);
+    this.gridLinesVertexBuffer = getVerticesBuffer(this.device, gridLinesVertexArray);
+
+    this.prototypeVertexBuffer = getVerticesBuffer(this.device, cubeVertexArray);
+  }
+
+  buildPipelines(presentationFormat, agentInstanceByteSize: number, agentPositionOffset: number, agentColorOffset:number) {
+
+    this.platformPipeline = getPipeline(
+      this.device, renderWGSL, 'vs_main', 'fs_platform', platformVertexSize,
+      platformPositionOffset, platformUVOffset, presentationFormat, 'triangle-list', 'back'
+    );
+
+    this.gridLinesPipeline = getPipeline(
+      this.device, renderWGSL, 'vs_main', 'fs_gridLines', gridLinesVertexSize,
+      gridLinesPositionOffset, gridLinesUVOffset, presentationFormat, 'line-list', 'none'
+    );
+
+    this.crowdPipeline = getCrowdRenderPipeline(
+      this.device, crowdWGSL, agentInstanceByteSize, agentPositionOffset, 
+      agentColorOffset, cubeVertexSize, cubePositionOffset, cubeUVOffset, presentationFormat
+    );
+  }
+
+  setBindGroups() {
+    this.platformUniformBuffer = getUniformBuffer(this.device, 4 * 16);
+    this.gridLinesUniformBuffer = getUniformBuffer(this.device, 4 * 16);
+    this.crowdUniformBuffer = getUniformBuffer(this.device, 4 * 16);
+
+    this.platformBindGroup = getUniformBindGroup(this.device, this.platformPipeline, this.platformUniformBuffer);
+    this.gridLinesBindGroup = getUniformBindGroup(this.device, this.gridLinesPipeline, this.gridLinesUniformBuffer);
+    this.crowdBindGroup = getUniformBindGroup(this.device, this.crowdPipeline, this.crowdUniformBuffer);
+  }
+  
+  setRenderPassDescriptor(presentationSize) {
+    // Get the depth texture for both pipelines
+    const depthTexture = getDepthTexture(this.device, presentationSize);
+
+    this.renderPassDescriptor = {
+      colorAttachments: [
+        {
+          view: undefined, // Assigned later
+
+          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          storeOp: 'store',
+        },
+      ],
+      depthStencilAttachment: {
+        view: depthTexture.createView(),
+
+        depthLoadValue: 1.0,
+        depthStoreOp: 'store',
+        stencilLoadValue: 0,
+        stencilStoreOp: 'store',
+      },
+    };
+  }
+
+  resetGridLinesBuffer(gridWidth: number) {
+    // Compute the grid lines based on an input gridWidth
+    let gridLinesVertexArray = getGridLines(gridWidth);
+    this.gridLinesVertexBuffer = getVerticesBuffer(this.device, gridLinesVertexArray);
+  }
+
+  drawPlatform(device: GPUDevice, transformationMatrix: Float32Array, passEncoder: GPURenderPassEncoder) {
+    device.queue.writeBuffer(
+      this.platformUniformBuffer,
+      0,
+      transformationMatrix.buffer,
+      transformationMatrix.byteOffset,
+      transformationMatrix.byteLength
+    );
+    passEncoder.setPipeline(this.platformPipeline);
+    passEncoder.setBindGroup(0, this.platformBindGroup);
+    passEncoder.setVertexBuffer(0, this.platformVertexBuffer);
+    passEncoder.draw(platformVertexCount, 1, 0, 0);
+  }
+
+  drawGridLines(device: GPUDevice, transformationMatrix: Float32Array, passEncoder: GPURenderPassEncoder, gridOn: boolean) {
+    if (gridOn){
+      device.queue.writeBuffer(
+        this.gridLinesUniformBuffer,
+        0,
+        transformationMatrix.buffer,
+        transformationMatrix.byteOffset,
+        transformationMatrix.byteLength
+      );
+      passEncoder.setPipeline(this.gridLinesPipeline);
+      passEncoder.setBindGroup(0, this.gridLinesBindGroup);
+      passEncoder.setVertexBuffer(0, this.gridLinesVertexBuffer);
+      passEncoder.draw(gridLinesVertexCount, 1, 0, 0);
+    }
+  }
+
+  drawCrowd(device: GPUDevice, mvp: mat4, passEncoder: GPURenderPassEncoder, agentsBuffer: GPUBuffer, numAgents: number) {
+      device.queue.writeBuffer(
+        this.crowdUniformBuffer,
+        0,
+          new Float32Array([
+          // modelViewProjectionMatrix
+          mvp[0],  mvp[1],  mvp[2],  mvp[3],
+          mvp[4],  mvp[5],  mvp[6],  mvp[7],
+          mvp[8],  mvp[9],  mvp[10], mvp[11],
+          mvp[12], mvp[13], mvp[14], mvp[15],
+        ])
+      );
+      passEncoder.setPipeline(this.crowdPipeline);
+      passEncoder.setBindGroup(0, this.crowdBindGroup);
+      passEncoder.setVertexBuffer(0, agentsBuffer);
+      passEncoder.setVertexBuffer(1, this.prototypeVertexBuffer);
+      passEncoder.draw(cubeVertexCount, numAgents, 0, 0);
+      passEncoder.endPass();
+  }  
+};
+
+////////////////////////////////////////////////////////////////////////////////////////
+//                         renderBufferManager Helpers                                //
+////////////////////////////////////////////////////////////////////////////////////////
+
 // Create a vertex buffer from the given data
-export const getVerticesBuffer = (device: GPUDevice, vertexArray: Float32Array) => {
-    const vertexBuffer = device.createBuffer({
-        size: vertexArray.byteLength,
-        usage: GPUBufferUsage.VERTEX,
-        mappedAtCreation: true,
-    });
+const getVerticesBuffer = (device: GPUDevice, vertexArray: Float32Array) => {
+  const vertexBuffer = device.createBuffer({
+      size: vertexArray.byteLength,
+      usage: GPUBufferUsage.VERTEX,
+      mappedAtCreation: true,
+  });
   new Float32Array(vertexBuffer.getMappedRange()).set(vertexArray);
   vertexBuffer.unmap();
   return vertexBuffer;
 }
 
 // Create a pipeline given the parameters
-export const getPipeline = (device: GPUDevice, code, vertEntryPoint: string, fragEntryPoint: string, 
-                         arrayStride: number, posOffset: number, uvOffset: number, presentationFormat, primitiveType, cullMode) => {
+const getPipeline = (device: GPUDevice, code, vertEntryPoint: string, fragEntryPoint: string, 
+                            arrayStride: number, posOffset: number, uvOffset: number, presentationFormat, primitiveType, cullMode) => {
   const pipeline = device.createRenderPipeline({
     vertex: {
       module: device.createShaderModule({
-        code: code,
-      }),
-      entryPoint: vertEntryPoint,
+      code: code,
+    }),
+    entryPoint: vertEntryPoint,
       buffers: [
-        {
-          arrayStride: arrayStride,
-          attributes: [
-            {
-              // position
-              shaderLocation: 0,
-              offset: posOffset,
-              format: 'float32x4',
-            },
-            {
-              // uv
-              shaderLocation: 1,
-              offset: uvOffset,
-              format: 'float32x2',
-            },
-          ],
-        },
+      {
+        arrayStride: arrayStride,
+        attributes: [
+          {
+            // position
+            shaderLocation: 0,
+            offset: posOffset,
+            format: 'float32x4',
+          },
+          {
+            // uv
+            shaderLocation: 1,
+            offset: uvOffset,
+            format: 'float32x2',
+          },
+        ],
+      },
       ],
     },
     fragment: {
@@ -45,9 +230,9 @@ export const getPipeline = (device: GPUDevice, code, vertEntryPoint: string, fra
       }),
       entryPoint: fragEntryPoint,
       targets: [
-        {
-          format: presentationFormat,
-        },
+      {
+        format: presentationFormat,
+      },
       ],
     },
     primitive: {
@@ -67,51 +252,51 @@ export const getPipeline = (device: GPUDevice, code, vertEntryPoint: string, fra
 }
 
 // TODO: There's probably a way to combine getCrowdRenderPipeline() with getPipeline()
-export const getCrowdRenderPipeline = (device: GPUDevice, code, arrayStride: number, posOffset: number, colOffset: number, 
-  vertArrayStride: number, vertPosOffset: number, vertUVOffset: number, presentationFormat) => {
+const getCrowdRenderPipeline = (device: GPUDevice, code, arrayStride: number, posOffset: number, colOffset: number, 
+                                       vertArrayStride: number, vertPosOffset: number, vertUVOffset: number, presentationFormat) => {
   const renderPipelineCrowd = device.createRenderPipeline({
     vertex: {
       module: device.createShaderModule({
         code: code,
       }),
-      entryPoint: 'vs_main',
-      buffers: [
+    entryPoint: 'vs_main',
+    buffers: [
+    {
+      // instanced agents buffer
+      arrayStride: arrayStride,
+      stepMode: 'instance',
+      attributes: [
         {
-          // instanced agents buffer
-          arrayStride: arrayStride,
-          stepMode: 'instance',
-          attributes: [
-            {
-              // position
-              shaderLocation: 0,
-              offset: posOffset,
-              format: 'float32x3',
-            },
-            {
-              // color
-              shaderLocation: 1,
-              offset: colOffset,
-              format: 'float32x4',
-            },
-          ],
+          // position
+          shaderLocation: 0,
+          offset: posOffset,
+          format: 'float32x3',
         },
         {
-          arrayStride: vertArrayStride,
-          attributes: [
-            {
-              // position
-              shaderLocation: 2,
-              offset: vertPosOffset,
-              format: 'float32x4',
-            },
-            {
-              // uv
-              shaderLocation: 3,
-              offset: vertUVOffset,
-              format: 'float32x2',
-            },
-          ],
+          // color
+          shaderLocation: 1,
+          offset: colOffset,
+          format: 'float32x4',
         },
+      ],
+    },
+    {
+      arrayStride: vertArrayStride,
+      attributes: [
+        {
+          // position
+          shaderLocation: 2,
+          offset: vertPosOffset,
+          format: 'float32x4',
+        },
+        {
+          // uv
+          shaderLocation: 3,
+          offset: vertUVOffset,
+          format: 'float32x2',
+        },
+        ],
+      },
       ],
     },
     fragment: {
@@ -138,7 +323,7 @@ export const getCrowdRenderPipeline = (device: GPUDevice, code, arrayStride: num
   return renderPipelineCrowd;
 };
 
-export const getDepthTexture = (device: GPUDevice, presentationSize) => {
+const getDepthTexture = (device: GPUDevice, presentationSize) => {
   const depthTexture = device.createTexture({
     size: presentationSize,
     format: 'depth24plus',
@@ -147,26 +332,26 @@ export const getDepthTexture = (device: GPUDevice, presentationSize) => {
   return depthTexture;
 }
 
-export const getUniformBuffer = (device: GPUDevice, size: number) => {
+const getUniformBuffer = (device: GPUDevice, size: number) => {
   const uniformBufferSize = size; // 4x4 matrix
   const uniformBuffer = device.createBuffer({
-    size: uniformBufferSize,
-    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  size: uniformBufferSize,
+  usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
   });
   return uniformBuffer;
 };
-  
-export const getUniformBindGroup = (device: GPUDevice, pipeline: GPURenderPipeline, uniformBuffer: GPUBuffer) => {
+
+const getUniformBindGroup = (device: GPUDevice, pipeline: GPURenderPipeline, uniformBuffer: GPUBuffer) => {
   const uniformBindGroup = device.createBindGroup({
-    layout: pipeline.getBindGroupLayout(0),
-    entries: [
-      {
-        binding: 0,
-        resource: {
-          buffer: uniformBuffer,
-        },
+  layout: pipeline.getBindGroupLayout(0),
+  entries: [
+    {
+      binding: 0,
+      resource: {
+        buffer: uniformBuffer,
       },
-    ],
+    },
+  ],
   });
   return uniformBindGroup;
 }

--- a/src/sample/crowd/shaders.wgsl
+++ b/src/sample/crowd/shaders.wgsl
@@ -6,6 +6,11 @@
     modelViewProjectionMatrix : mat4x4<f32>;
   };
   [[binding(0), group(0)]] var<uniform> uniforms : Uniforms;
+
+[[block]] struct Neighbors {
+  neighbors : array<u32>;
+};
+[[binding(1), group(0)]] var<storage> neighborData : Neighbors;
   
   struct VertexOutput {
     [[builtin(position)]] Position : vec4<f32>;

--- a/src/shaders/findNeighbors.wgsl
+++ b/src/shaders/findNeighbors.wgsl
@@ -33,16 +33,45 @@ struct Cell {
   cells : array<Cell>;
 };
 
+[[block]] struct Neighbors {
+  neighbors: array<u32>;
+};
+
 [[binding(0), group(0)]] var<uniform> sim_params : SimulationParams;
 [[binding(1), group(0)]] var<storage, read_write> agentData : Agents;
 [[binding(2), group(0)]] var<storage, read_write> goalData : GoalData;
 [[binding(3), group(0)]] var<storage, read_write> gridCell : GridCells;
+[[binding(4), group(0)]] var<storage, read_write> neighborData : Neighbors;
 
 [[stage(compute), workgroup_size(64)]]
 fn main([[builtin(global_invocation_id)]] GlobalInvocationID : vec3<u32>) {
 
-  let idx = GlobalInvocationID.x;
+  var idx = GlobalInvocationID.x;
   var agent = agentData.agents[idx];
+  var radius = 5.0;
+
+  var neighborIdx = 0;
+  // loop through agents, find neighbors, and save their indices to the neighbor buffer
+  for (var i : u32 = 0u; i < arrayLength(&agentData.agents); i = i + 1u) {
+    var potentialNeighbor = agentData.agents[i];
+    if (distance(potentialNeighbor.position, agent.position) < radius) {
+      neighborData.neighbors[neighborIdx] = i;
+      neighborIdx = neighborIdx + 1;
+      if (idx == 0u) {
+        potentialNeighbor.color = vec4<f32>(0.0, 1.0, 0.0, 1.0);
+      }
+    }   
+  }
+
+  if (idx == 0u){
+    agent.color = vec4<f32>(0.0, 1.0, 0.0, 1.0);
+  }
+  if (distance(agent.position, agentData.agents[0].position) < radius) {
+    agent.color = vec4<f32>(0.0, 1.0, 0.0, 1.0);
+  }
+  else{
+    agent.color = vec4<f32>(0.9, 0.9, 0.9, 1.0);
+  }
 
   // use calculated velocity to set the new position
   //agent.position = agent.position + sim_params.deltaTime * agent.velocity;

--- a/src/shaders/planVelocity.wgsl
+++ b/src/shaders/planVelocity.wgsl
@@ -67,8 +67,9 @@ fn main([[builtin(global_invocation_id)]] GlobalInvocationID : vec3<u32>) {
   let goal = goalData.goals[idx];
 
   // a biased random velocity averaged with the agent's previous velocity
-  let randVel = vec3<f32>((rand() * 2.0) - 1.0, 0.0, (rand() * 2.0) - 1.0);
-  agent.velocity = 0.5 * (agent.velocity + (goal + randVel));
+  //let randVel = vec3<f32>((rand() * 2.0) - 1.0, 0.0, (rand() * 2.0) - 1.0);
+  //agent.velocity = 0.5 * (agent.velocity + (goal + randVel));
+  agent.velocity = 0.5 * (agent.velocity + (goal));
 
   // Store the new agent value
   agentData.agents[idx] = agent;


### PR DESCRIPTION
- does a naive neighbor search and sets up the neighbors buffer: [neighbor1Agent1, neighbor2Agent1, neighbor3Agent1, neighbor1Agent2, etc...]
- performed an initial test to make sure this works -- only really confirmed that the method of doing this is legitimate (hard to confirm that the data in the neighbors buffer is correct, since you can't set the color for other agents -- I think it's a writing conflict)
- note that I changed some of the planned velocity stuff @mattelser because it was spreading too far to see results. Feel free to change it back. Also started the agents closer to the plane

- @mattelser @wayne-wu this restructures the rendering since I created a renderBufferManager akin to the computeBufferManager
- Y'all might want to look this over before I merge to make sure I'm not throwing a wrench in whatever y'all are working on